### PR TITLE
Pin rust to rust-version in Cargo.toml, increase swapfile size

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -46,7 +46,7 @@ jobs:
          df -h
     displayName: Manage disk space
   - script: |
-         sudo fallocate -l 15GiB /swapfile || true
+         sudo fallocate -l 20GiB /swapfile || true
          sudo chmod 600 /swapfile || true
          sudo mkswap /swapfile || true
          sudo swapon /swapfile || true

--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -46,7 +46,7 @@ jobs:
          df -h
     displayName: Manage disk space
   - script: |
-         sudo fallocate -l 10GiB /swapfile || true
+         sudo fallocate -l 15GiB /swapfile || true
          sudo chmod 600 /swapfile || true
          sudo mkswap /swapfile || true
          sudo swapon /swapfile || true

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -21,7 +21,7 @@ docker_image:
 rust_compiler:
 - rust
 rust_compiler_version:
-- '1.87'
+- '1.85'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -20,6 +20,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 rust_compiler:
 - rust
+rust_compiler_version:
+- '1.87'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -21,7 +21,7 @@ docker_image:
 rust_compiler:
 - rust
 rust_compiler_version:
-- '1.85'
+- '1.86'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -21,7 +21,7 @@ docker_image:
 rust_compiler:
 - rust
 rust_compiler_version:
-- '1.85'
+- '1.86'
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -21,7 +21,7 @@ docker_image:
 rust_compiler:
 - rust
 rust_compiler_version:
-- '1.87'
+- '1.85'
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -20,6 +20,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 rust_compiler:
 - rust
+rust_compiler_version:
+- '1.87'
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -20,6 +20,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 rust_compiler:
 - rust
+rust_compiler_version:
+- '1.87'
 target_platform:
 - linux-ppc64le
 zip_keys:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -21,7 +21,7 @@ docker_image:
 rust_compiler:
 - rust
 rust_compiler_version:
-- '1.85'
+- '1.86'
 target_platform:
 - linux-ppc64le
 zip_keys:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -21,7 +21,7 @@ docker_image:
 rust_compiler:
 - rust
 rust_compiler_version:
-- '1.87'
+- '1.85'
 target_platform:
 - linux-ppc64le
 zip_keys:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -23,7 +23,7 @@ macos_machine:
 rust_compiler:
 - rust
 rust_compiler_version:
-- '1.85'
+- '1.86'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -23,7 +23,7 @@ macos_machine:
 rust_compiler:
 - rust
 rust_compiler_version:
-- '1.87'
+- '1.85'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -22,6 +22,8 @@ macos_machine:
 - x86_64-apple-darwin13.4.0
 rust_compiler:
 - rust
+rust_compiler_version:
+- '1.87'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -22,6 +22,8 @@ macos_machine:
 - arm64-apple-darwin20.0.0
 rust_compiler:
 - rust
+rust_compiler_version:
+- '1.87'
 target_platform:
 - osx-arm64
 zip_keys:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -23,7 +23,7 @@ macos_machine:
 rust_compiler:
 - rust
 rust_compiler_version:
-- '1.87'
+- '1.85'
 target_platform:
 - osx-arm64
 zip_keys:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -23,7 +23,7 @@ macos_machine:
 rust_compiler:
 - rust
 rust_compiler_version:
-- '1.85'
+- '1.86'
 target_platform:
 - osx-arm64
 zip_keys:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -10,5 +10,7 @@ cxx_compiler:
 - vs2022
 rust_compiler:
 - rust
+rust_compiler_version:
+- '1.87'
 target_platform:
 - win-64

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -11,6 +11,6 @@ cxx_compiler:
 rust_compiler:
 - rust
 rust_compiler_version:
-- '1.87'
+- '1.85'
 target_platform:
 - win-64

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -11,6 +11,6 @@ cxx_compiler:
 rust_compiler:
 - rust
 rust_compiler_version:
-- '1.85'
+- '1.86'
 target_platform:
 - win-64

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,7 +1,7 @@
 azure:
   free_disk_space: true
   settings_linux:
-    swapfile_size: 10GiB
+    swapfile_size: 15GiB
   settings_win:
     variables:
       SET_PAGEFILE: 'True'

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,7 +1,7 @@
 azure:
   free_disk_space: true
   settings_linux:
-    swapfile_size: 15GiB
+    swapfile_size: 20GiB
   settings_win:
     variables:
       SET_PAGEFILE: 'True'

--- a/recipe/build-uv.sh
+++ b/recipe/build-uv.sh
@@ -1,6 +1,19 @@
 #!/usr/bin/env bash
 set -eux
 
+echo "ensuring rust-version in Cargo.toml:#/workspace/package/rust-version is ${CBC_RUST_VERSION}"
+CARGO_TOML_RUST_VERSION=$(grep -iE "rust-version = \".*\"" Cargo.toml)
+
+if [[ "${CARGO_TOML_RUST_VERSION}" == "rust-version = \"${CBC_RUST_VERSION}\"" ]] ;
+then
+  echo "OK rust version in Cargo.toml and conda_build_config.yaml agree: ${CBC_RUST_VERSION}"
+else
+  echo "ERROR rust version unexpcted"
+  echo "... please update recipe/conda_build_config.yaml#/rust_compiler_version"
+  echo "    to match ${CARGO_TOML_RUST_VERSION}"
+  exit 2
+fi
+
 export CARGO_PROFILE_RELEASE_STRIP=symbols
 
 # see https://github.com/conda-forge/uv-feedstock/pull/202#issuecomment-2890816026

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,2 @@
+rust_compiler_version:
+  - "1.87"

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,3 @@
+# `build-uv-sh` compares this against `Cargo.toml#/workspace/package/rust-version`
 rust_compiler_version:
-  - "1.87"
+  - "1.85"

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,3 @@
 # `build-uv-sh` compares this against `Cargo.toml#/workspace/package/rust-version`
 rust_compiler_version:
-  - "1.85"
+  - "1.86"

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -15,7 +15,7 @@ source:
     - 0000-no-link-static-vc-runtime.patch
 
 build:
-  number: 0
+  number: 1
   script:
     file: build-uv
     env:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -22,7 +22,7 @@ build:
       # This env var specifies the base 2 log of the allocator page size
       JEMALLOC_SYS_WITH_LG_PAGE: ${{ "16" if target_platform == "linux-aarch64" or target_platform == "linux-ppc64le" }}
       # used in `build-uv.sh` to verity the expected version of rust
-      CBC_RUST_COMPILER_VERSION: ${{ rust_compiler_version | default(".*") }}
+      CBC_RUST_VERSION: ${{ rust_compiler_version | default(".*") }}
 
 requirements:
   build:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -21,6 +21,8 @@ build:
     env:
       # This env var specifies the base 2 log of the allocator page size
       JEMALLOC_SYS_WITH_LG_PAGE: ${{ "16" if target_platform == "linux-aarch64" or target_platform == "linux-ppc64le" }}
+      # used in `build-uv.sh` to verity the expected version of rust
+      CBC_RUST_COMPILER_VERSION: ${{ rust_compiler_version | default(".*") }}
 
 requirements:
   build:


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Changes:
- [x] pin to `rust 1.85` to match `Cargo.toml`
- [x] preflight `rust` version in `build-uv.sh`   
- [x] bump `swapfile_size` 

Notes:
- for persistent issues in `ppc64le` builds observed after merging #218 
